### PR TITLE
Feature/pske 1.83.2/hide regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ git cherry-pick 58794f50  # PDB + podAntiAffinity
 git cherry-pick 1b2ae8b7  # Remove unused UI components
 git cherry-pick 69601441  # Cilium as default network type
 git cherry-pick f7f81ebd  # Remove Credential Rotation from menu
+git cherry-pick 249d7612  # Filter credentials by cloud profile label
 
 # 4. Push and create PR
 git push origin release/pske-1.85.0
@@ -74,3 +75,4 @@ yarn dev
 | `69601441` | Cilium as default network type |
 | `f7f81ebd` | Remove Credential Rotation from menu |
 | `cebf8fa8` | Remove Add-ons section from cluster details |
+| `249d7612` | Filter credentials by cloud profile label |

--- a/frontend/src/composables/useShootHelper.js
+++ b/frontend/src/composables/useShootHelper.js
@@ -85,7 +85,26 @@ export function createShootHelperComposable (shootItem, options = {}) {
   })
 
   const cloudProfiles = computed(() => {
-    return cloudProfileStore.cloudProfilesByProviderType(providerType.value)
+    const allProfiles = cloudProfileStore.cloudProfilesByProviderType(providerType.value)
+    const bindings = credentialStore.infrastructureBindingList
+
+    // only show cloud profiles where the user has a secret for
+    const filteredProfiles = []
+    for (const profile of allProfiles) {
+      const profileName = profile.metadata.name
+      const hasSecret = bindings.some(b => {
+        const label = b.metadata?.labels?.['cloudprofile.garden.sapcloud.io/name']
+        return label === profileName
+      })
+      if (hasSecret) {
+        filteredProfiles.push(profile)
+      }
+    }
+
+    // fallback: if no bindings have the label at all, show everything
+    if (filteredProfiles.length === 0) return allProfiles
+
+    return filteredProfiles
   })
 
   const defaultCloudProfileRef = computed(() => {


### PR DESCRIPTION
**How to categorize this PR?**  
<!--
Please select a kind for this pull request. This helps the reviewers categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
"/kind" identifiers:     feature|bug|documentation|cleanup|dependency
-->
/kind feature

**What this PR does / why we need it**:  

When creating a new shoot cluster, the dashboard currently shows all cloud profiles and credentials for a given provider type, regardless of whether the user actually has a secret configured for them.

In our setup, each cloud profile corresponds to a specific region and secrets are labeled with cloudprofile.garden.sapcloud.io/name to indicate which cloud profile they belong to.

**Which issue(s) this PR fixes**:  
Fixes #MK-3180

**Author's Checklist**
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

**Special notes for your reviewer**:  

**Breaking changes**
<!--
If your pull request introduces breaking changes, please add the respective label and manual steps:

/label breaking
```bash
# TODO: ADD INSTRUCTION
```
-->